### PR TITLE
Include AccountId when generating authority keys

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -37,8 +37,9 @@ pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId where
 }
 
 /// Helper function to generate an authority key for Aura
-pub fn authority_keys_from_seed(s: &str) -> (AuraId, GrandpaId) {
+pub fn authority_keys_from_seed(s: &str) -> (AccountId, AuraId, GrandpaId) {
 	(
+		get_account_id_from_seed::<sr25519::Public>(s),
 		get_from_seed::<AuraId>(s),
 		get_from_seed::<GrandpaId>(s),
 	)
@@ -105,7 +106,7 @@ pub fn local_testnet_config() -> ChainSpec {
 	)
 }
 
-fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
+fn testnet_genesis(initial_authorities: Vec<(AccountId, AuraId, GrandpaId)>,
 	root_key: AccountId,
 	endowed_accounts: Vec<AccountId>,
 	_enable_println: bool) -> GenesisConfig {
@@ -118,10 +119,10 @@ fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
 			balances: endowed_accounts.iter().cloned().map(|k|(k, 1 << 60)).collect(),
 		}),
 		aura: Some(AuraConfig {
-			authorities: initial_authorities.iter().map(|x| (x.0.clone())).collect(),
+			authorities: vec![],
 		}),
 		grandpa: Some(GrandpaConfig {
-			authorities: initial_authorities.iter().map(|x| (x.1.clone(), 1)).collect(),
+			authorities: vec![],
 		}),
 		sudo: Some(SudoConfig {
 			key: root_key,
@@ -129,8 +130,8 @@ fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
 		pallet_session: Some(SessionConfig {
 			keys: initial_authorities.iter().map(|x| {
 				(x.0.clone(), x.0.clone(), session_keys(
-					x.0.clone(),
 					x.1.clone(),
+					x.2.clone(),
 				))
 			}).collect::<Vec<_>>(),
 		}),


### PR DESCRIPTION
This PR solves the compilation issue reported in https://github.com/paritytech/subport/issues/22

It makes 2 primary changes, both in the `chain+spec.rs` file:
1. When generating authority keys from a seed, it also generates the AccountId associated with that seed.
2. It removes the authorities from the aura and grandpa configurations as the authorities will be managed by the sessions pallet.

## What was Wrong Before?

When you manage your authorities directly with the aura and grandpa pallets like the unmodified node template does, you are managing the set of keys that nodes will actually sign blocks with. This is a very simple approach and it has all the usual benefits and drawbacks of simplicity. It's easy to understand and requires little code. But it isn't very flexable, and requires validators to protect their keys for long periods of time with no way to recover when they make a mistake.

When you choose to use the session pallet, you're choosing to think of the validators as set of [`ValidatorId`](https://substrate.dev/rustdocs/v2.0.0-rc3/pallet_session/trait.Trait.html#associatedtype.ValidatorId)s. A `ValidatorId` is a long-lasting "name" for a validator. In this code [you have chosen](https://github.com/noahsalvadordenjo/sub/blob/6163d89daa9ba92f2cb665da4497e7ec4fa8cba8/runtime/src/lib.rs#L267) to use a regular old `AccountId` as your `ValidatorId`. This is a reasonable and normal choice.

The sessions pallet allows you to associate the actual keys validators use to sign blocks, called "session keys", with these long-lives `ValidatorId`s. It also allows validators to rotate the their keys whenever they like. The problem is that you were trying to use one of the session keys (specifically the aura key) where the `AccountId` was required.

This whole thing is further complicated by the fact that both the aura key and the `AccountId` use sr25519 crypto. So bit-wise they are exactly the same key. However, Rust;s type-checker know that in general this may not be the case, and insist that you specify a properly-typed `AccountId`.